### PR TITLE
use ${BASH_SOURCE[0]} in place of $0

### DIFF
--- a/czmod.bash
+++ b/czmod.bash
@@ -1,10 +1,10 @@
 #! /usr/bin/bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
 CZMODPATH="$SCRIPTPATH/czmod"
 
 if [ ! -x "$CZMODPATH" ]; then
-	SCRIPTPATH="$(readlink """$0""")"
+	SCRIPTPATH="$(readlink """${BASH_SOURCE[0]}""")"
 	SCRIPTPATH="$( cd "$(dirname "$SCRIPTPATH")" >/dev/null 2>&1 ; pwd -P )"
 	CZMODPATH="$SCRIPTPATH/czmod"
 fi


### PR DESCRIPTION
${BASH_SOURCE[0]} (or, more simply, $BASH_SOURCE[1] ) contains the (potentially relative) path of the containing script in all invocation scenarios, notably also when the script is sourced, which is not true for $0. (source: https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source)